### PR TITLE
Remove filter in when

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -46,20 +46,20 @@
 - name: PROMETHEUS | Obtain installed version
   set_fact:
     prometheus_installed_version:  "{{ prometheus_version.startswith('2') | ternary(prometheus_check.stderr, prometheus_check.stdout) }}"
-  when: prometheus_check|succeeded
+  when: prometheus_check is succeeded
 
 - name: PROMETHEUS | Download package
   get_url:
     url: "{{ prometheus_url }}"
     dest: "/tmp/{{ prometheus_package }}"
-  when: prometheus_force_reinstall or prometheus_check|failed or prometheus_installed_version is not search('prometheus, version ' + prometheus_version)
+  when: prometheus_force_reinstall or prometheus_check is failed or prometheus_installed_version is not search('prometheus, version ' + prometheus_version)
 
 - name: PROMETHEUS | Extract package
   unarchive:
     copy: no
     src: "/tmp/{{ prometheus_package }}"
     dest: /tmp
-  when: prometheus_force_reinstall or prometheus_check|failed or prometheus_installed_version is not search('prometheus, version ' + prometheus_version)
+  when: prometheus_force_reinstall or prometheus_check is failed or prometheus_installed_version is not search('prometheus, version ' + prometheus_version)
 
 - name: PROMETHEUS | Copy binary
   copy:
@@ -72,7 +72,7 @@
   with_items:
     - prometheus
     - promtool
-  when: prometheus_force_reinstall or prometheus_check|failed or prometheus_installed_version is not search('prometheus, version ' + prometheus_version)
+  when: prometheus_force_reinstall or prometheus_check is failed or prometheus_installed_version is not search('prometheus, version ' + prometheus_version)
   notify: restart prometheus
 
 - name: PROMETHEUS | Link binary


### PR DESCRIPTION
This PR removes the usage of filters `variable|some-filter` in `when` (it's no longer supported).